### PR TITLE
Add Blade filetype

### DIFF
--- a/lua/nvim-ts-autotag/internal.lua
+++ b/lua/nvim-ts-autotag/internal.lua
@@ -16,6 +16,7 @@ M.tbl_filetypes = {
     'htmldjango',
     'eruby',
     'templ',
+    'blade',
 }
 
 -- stylua: ignore
@@ -33,6 +34,7 @@ local HTML_TAG = {
         'markdown',
         'php',
         'xml',
+        'blade',
     },
     start_tag_pattern      = { 'start_tag', 'STag' },
     start_name_tag_pattern = { 'tag_name', 'Name' },


### PR DESCRIPTION
I wanted to do this for a while, but since the old maintainer was on hiatus I didn't do it.

This PR adds recognition for the Blade (Laravel) filetype. It doesn't seem to indent properly when you press Return:
```
<p></p>
```
`RET`
```
<p>
</p>
```
I don't know enough Lua or the codebase to get that working. Otherwise, I've been using it for a month now and it works.